### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/sources/slicesrc.go
+++ b/sources/slicesrc.go
@@ -15,7 +15,7 @@ type SliceSrc struct {
 	log    *log.Logger
 }
 
-// SliceSrc creates new slice source
+// Slice creates new slice source
 func Slice(elems ...interface{}) *SliceSrc {
 	return &SliceSrc{
 		src:    elems,
@@ -23,7 +23,7 @@ func Slice(elems ...interface{}) *SliceSrc {
 	}
 }
 
-// GetOuptut returns the output channel of this source node
+// GetOutput returns the output channel of this source node
 func (s *SliceSrc) GetOutput() <-chan interface{} {
 	return s.output
 }

--- a/stream/binaryop.go
+++ b/stream/binaryop.go
@@ -23,7 +23,7 @@ type BinaryOp struct {
 	mutex       sync.RWMutex
 }
 
-// NewBinOp creates a new binary operation executor
+// NewBinaryOp creates a new binary operation executor
 func NewBinaryOp(ctx context.Context) *BinaryOp {
 	// extract logger
 	log := autoctx.GetLogger(ctx)

--- a/stream/drain.go
+++ b/stream/drain.go
@@ -26,7 +26,7 @@ func (s *Drain) SetInput(in <-chan interface{}) {
 	s.input = in
 }
 
-// GetOuput returns output channel for stream node
+// GetOutput returns output channel for stream node
 func (s *Drain) GetOutput() <-chan interface{} {
 	return s.output
 }

--- a/stream/streamop.go
+++ b/stream/streamop.go
@@ -19,7 +19,7 @@ type StreamOp struct {
 	log    *log.Logger
 }
 
-// NewSteamOp creates a *StreamOp value
+// NewStreamOp creates a *StreamOp value
 func NewStreamOp(ctx context.Context) *StreamOp {
 	log := autoctx.GetLogger(ctx)
 

--- a/stream/unaryop.go
+++ b/stream/unaryop.go
@@ -30,7 +30,7 @@ type UnaryOp struct {
 	mutex       sync.RWMutex
 }
 
-// NewUnary creates *UnaryOp value
+// NewUnaryOp creates *UnaryOp value
 func NewUnaryOp(ctx context.Context) *UnaryOp {
 	// extract logger
 	log := autoctx.GetLogger(ctx)

--- a/testutil/genwords.go
+++ b/testutil/genwords.go
@@ -21,7 +21,7 @@ func GenWord() string {
 	return GenWordn(n)
 }
 
-// GenWordWithLen generates a random world of N length
+// GenWordn generates a random world of N length
 func GenWordn(n int) string {
 	if n < 1 {
 		n = 12


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._
