### PR TITLE
feat: Add ChanSink for sending stream items to a Go channel (attempt 2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -254,6 +254,7 @@ func TestSinkFunc(t *testing.T) {
 Automi provides several built-in sinks to suit various use cases:
 
 - `sinks.CSV`: Writes items in CSV format
+- `sinks.Chan[T]`: Sends items of type T to a Go channel
 - `sinks.Func[T](func(T)error)`: Processes items using a user-defined function
 - `sinks.Discard`: Ignores all items (no-op sink)
 - `sinks.Slice[T]`: Appends items of type T to a Go slice

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/vladimirvivien/automi
 
 go 1.23.5
 
-toolchain go1.23.5
-
 require github.com/vladimirvivien/gexe v0.4.1

--- a/operators/exec/operator_test.go
+++ b/operators/exec/operator_test.go
@@ -279,6 +279,23 @@ func TestExecOperator(t *testing.T) {
 	})
 }
 
+func TestExecOperator_InputChannelNotSet(t *testing.T) {
+	// Create an exec operator without setting input channel
+	op := New(func(ctx context.Context, item any) any {
+		return item
+	})
+
+	// Call Exec without setting input - should return ErrInputChannelUndefined
+	err := op.Exec(context.TODO())
+	if err == nil {
+		t.Fatal("Expected error when input channel is not set, but got nil")
+	}
+
+	if err != api.ErrInputChannelUndefined {
+		t.Fatalf("Expected ErrInputChannelUndefined, but got: %v", err)
+	}
+}
+
 func BenchmarkExecOperator(b *testing.B) {
 	N := b.N
 

--- a/sinks/chansink.go
+++ b/sinks/chansink.go
@@ -9,39 +9,43 @@ import (
 	"github.com/vladimirvivien/automi/log"
 )
 
-// ChanSink sends streamed items to an output channel.
-type ChanSink[T any] struct {
-	output chan T
+// ChanSink represents a sink backed by a Go channel.
+type ChanSink[IN any, CHAN <-chan IN] struct {
+	chansink chan IN
 	input  <-chan any
 	logf   api.StreamLogFunc
 }
 
-// Chan is the constructor function which returns a new ChanSink.
-func Chan[T any](outputChan chan T) *ChanSink[T] {
-	return &ChanSink[T]{
-		output: outputChan,
+// BufferedChan returns a new ChanSink backed by a buffered channel.
+func BufferedChan[IN any, CHAN <-chan IN](bufferSize int) *ChanSink[IN,CHAN] {
+	return &ChanSink[IN,CHAN]{
+		chansink: make(chan IN, bufferSize),
 		logf:   log.NoLogFunc,
 	}
 }
 
-// SetInput sets the source for the sink.
-func (s *ChanSink[T]) SetInput(in <-chan any) {
+// Chan returns a new ChanSink backed by an unbuffered channel.
+func Chan[IN any, CHAN <-chan IN]() *ChanSink[IN,CHAN] {
+	return BufferedChan[IN,CHAN](0)
+}
+
+// SetInput sets the input for the sink.
+func (s *ChanSink[IN,CHAN]) SetInput(in <-chan any) {
 	s.input = in
 }
 
-// Get returns the output channel used by the sink.
-func (s *ChanSink[T]) Get() <-chan T {
-	return s.output
+// Get returns a receive-only channel used by the sink.
+func (s *ChanSink[IN,CHAN]) Get() CHAN {
+	return s.chansink
 }
 
 // SetLogFunc sets a logging func for the component.
-func (s *ChanSink[T]) SetLogFunc(f api.StreamLogFunc) {
+func (s *ChanSink[IN,CHAN]) SetLogFunc(f api.StreamLogFunc) {
 	s.logf = f
 }
 
 // Open starts the sink and returns and waits on the returned
-// channel for the sink to be done or an error to be received.
-func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
+func (s *ChanSink[IN,CHAN]) Open(ctx context.Context) <-chan error {
 	result := make(chan error)
 
 	s.logf(ctx, log.LogInfo(
@@ -56,7 +60,7 @@ func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
 				"Component closing",
 				slog.String("sink", "Chan"),
 			))
-			close(s.output) // Ensure output channel is closed
+			close(s.chansink) // Ensure output channel is closed
 		}()
 
 		for {
@@ -65,7 +69,7 @@ func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
 				if !opened {
 					return
 				}
-				data, ok := item.(T)
+				data, ok := item.(IN)
 				if !ok {
 					s.logf(ctx, log.LogDebug(
 						"Error: unexpected data type",
@@ -74,7 +78,7 @@ func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
 					))
 					continue
 				}
-				s.output <- data
+				s.chansink <- data
 			case <-ctx.Done():
 				return
 			}

--- a/sinks/chansink.go
+++ b/sinks/chansink.go
@@ -1,0 +1,84 @@
+package sinks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/vladimirvivien/automi/api"
+	"github.com/vladimirvivien/automi/log"
+)
+
+// ChanSink sends streamed items to an output channel.
+type ChanSink[T any] struct {
+	output chan T
+	input  <-chan any
+	logf   api.StreamLogFunc
+}
+
+// Chan is the constructor function which returns a new ChanSink.
+func Chan[T any](outputChan chan T) *ChanSink[T] {
+	return &ChanSink[T]{
+		output: outputChan,
+		logf:   log.NoLogFunc,
+	}
+}
+
+// SetInput sets the source for the sink.
+func (s *ChanSink[T]) SetInput(in <-chan any) {
+	s.input = in
+}
+
+// Get returns the output channel used by the sink.
+func (s *ChanSink[T]) Get() <-chan T {
+	return s.output
+}
+
+// SetLogFunc sets a logging func for the component.
+func (s *ChanSink[T]) SetLogFunc(f api.StreamLogFunc) {
+	s.logf = f
+}
+
+// Open starts the sink and returns and waits on the returned
+// channel for the sink to be done or an error to be received.
+func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
+	result := make(chan error)
+
+	s.logf(ctx, log.LogInfo(
+		"Component starting",
+		slog.String("sink", "Chan"),
+	))
+
+	go func() {
+		defer func() {
+			close(result)
+			s.logf(ctx, log.LogInfo(
+				"Component closing",
+				slog.String("sink", "Chan"),
+			))
+		}()
+
+		for {
+			select {
+			case item, opened := <-s.input:
+				if !opened {
+					return
+				}
+				data, ok := item.(T)
+				if !ok {
+					s.logf(ctx, log.LogDebug(
+						"Error: unexpected data type",
+						slog.String("sink", "Chan"),
+						slog.String("type", fmt.Sprintf("%T", item)),
+					))
+					continue
+				}
+				s.output <- data
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return result
+}

--- a/sinks/chansink.go
+++ b/sinks/chansink.go
@@ -56,6 +56,7 @@ func (s *ChanSink[T]) Open(ctx context.Context) <-chan error {
 				"Component closing",
 				slog.String("sink", "Chan"),
 			))
+			close(s.output) // Ensure output channel is closed
 		}()
 
 		for {

--- a/sinks/chansink.go
+++ b/sinks/chansink.go
@@ -12,41 +12,51 @@ import (
 // ChanSink represents a sink backed by a Go channel.
 type ChanSink[IN any, CHAN <-chan IN] struct {
 	chansink chan IN
-	input  <-chan any
-	logf   api.StreamLogFunc
+	input    <-chan any
+	logf     api.StreamLogFunc
 }
 
 // BufferedChan returns a new ChanSink backed by a buffered channel.
-func BufferedChan[IN any, CHAN <-chan IN](bufferSize int) *ChanSink[IN,CHAN] {
-	return &ChanSink[IN,CHAN]{
+func BufferedChan[IN any, CHAN <-chan IN](bufferSize int) *ChanSink[IN, CHAN] {
+	return &ChanSink[IN, CHAN]{
 		chansink: make(chan IN, bufferSize),
-		logf:   log.NoLogFunc,
+		logf:     log.NoLogFunc,
 	}
 }
 
 // Chan returns a new ChanSink backed by an unbuffered channel.
-func Chan[IN any, CHAN <-chan IN]() *ChanSink[IN,CHAN] {
-	return BufferedChan[IN,CHAN](0)
+func Chan[IN any, CHAN <-chan IN]() *ChanSink[IN, CHAN] {
+	return BufferedChan[IN, CHAN](0)
 }
 
 // SetInput sets the input for the sink.
-func (s *ChanSink[IN,CHAN]) SetInput(in <-chan any) {
+func (s *ChanSink[IN, CHAN]) SetInput(in <-chan any) {
 	s.input = in
 }
 
 // Get returns a receive-only channel used by the sink.
-func (s *ChanSink[IN,CHAN]) Get() CHAN {
+func (s *ChanSink[IN, CHAN]) Get() CHAN {
 	return s.chansink
 }
 
 // SetLogFunc sets a logging func for the component.
-func (s *ChanSink[IN,CHAN]) SetLogFunc(f api.StreamLogFunc) {
+func (s *ChanSink[IN, CHAN]) SetLogFunc(f api.StreamLogFunc) {
 	s.logf = f
 }
 
 // Open starts the sink and returns and waits on the returned
-func (s *ChanSink[IN,CHAN]) Open(ctx context.Context) <-chan error {
+func (s *ChanSink[IN, CHAN]) Open(ctx context.Context) <-chan error {
 	result := make(chan error)
+
+	if s.input == nil {
+		go func() { result <- api.ErrInputChannelUndefined }()
+		return result
+	}
+
+	if s.chansink == nil {
+		go func() { result <- api.ErrSinkDestinationUndefined }()
+		return result
+	}
 
 	s.logf(ctx, log.LogInfo(
 		"Component starting",
@@ -62,6 +72,13 @@ func (s *ChanSink[IN,CHAN]) Open(ctx context.Context) <-chan error {
 			))
 			close(s.chansink) // Ensure output channel is closed
 		}()
+
+		if s.input == nil {
+			panic("ChanSink input not set")
+		}
+		if s.chansink == nil {
+			panic("ChanSink channel not set")
+		}
 
 		for {
 			select {

--- a/sinks/chansink_test.go
+++ b/sinks/chansink_test.go
@@ -8,10 +8,9 @@ import (
 )
 
 func TestChanSink_Open(t *testing.T) {
-	outputChan := make(chan string)
-	cs := Chan[string](outputChan)
+	cs := Chan[string]()
 
-	inputChan := make(chan interface{})
+	inputChan := make(chan any)
 	go func() {
 		inputChan <- "A"
 		inputChan <- "B"
@@ -23,7 +22,7 @@ func TestChanSink_Open(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	sinkErr := cs.Open(ctx)
+	sink := cs.Open(ctx)
 
 	var receivedData []string
 	doneReceiving := make(chan struct{})
@@ -36,7 +35,7 @@ func TestChanSink_Open(t *testing.T) {
 	}()
 
 	select {
-	case err := <-sinkErr:
+	case err := <-sink:
 		if err != nil {
 			t.Fatalf("ChanSink.Open() returned an error: %v", err)
 		}
@@ -54,18 +53,11 @@ func TestChanSink_Open(t *testing.T) {
 	if !reflect.DeepEqual(expectedData, receivedData) {
 		t.Errorf("Received data did not match expected data. Got %v, expected %v", receivedData, expectedData)
 	}
-
-	// Check if the sink's output channel was closed by the sink (indirectly via the receiving goroutine)
-	// This is a bit tricky to test directly for a send-only channel from the sink's perspective.
-	// However, if the receiving goroutine exited, it implies the channel was closed.
-	// A more direct test might involve trying to send to cs.Get() after it's supposed to be closed,
-	// but that's not how this sink is designed to be used.
 }
 
 func TestChanSink_Open_ContextCancel(t *testing.T) {
-	outputChan := make(chan int)
-	cs := Chan[int](outputChan)
-	inputChan := make(chan interface{})
+	cs := Chan[int]()
+	inputChan := make(chan any)
 
 	cs.SetInput(inputChan)
 
@@ -98,9 +90,8 @@ func TestChanSink_Open_ContextCancel(t *testing.T) {
 }
 
 func TestChanSink_Open_WrongDataType(t *testing.T) {
-	outputChan := make(chan string)
-	cs := Chan[string](outputChan) // Expecting string
-	inputChan := make(chan interface{})
+	cs := Chan[string]() // Expecting string
+	inputChan := make(chan any)
 
 	go func() {
 		inputChan <- "CorrectType"

--- a/sinks/chansink_test.go
+++ b/sinks/chansink_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/vladimirvivien/automi/api"
 )
 
 func TestChanSink_Open(t *testing.T) {
@@ -129,5 +131,28 @@ func TestChanSink_Open_WrongDataType(t *testing.T) {
 	expectedData := []string{"CorrectType", "AnotherCorrectType"}
 	if !reflect.DeepEqual(expectedData, receivedData) {
 		t.Errorf("Received data did not match expected data. Got %v, expected %v", receivedData, expectedData)
+	}
+}
+
+func TestChanSink_Open_InputChannelNotSet(t *testing.T) {
+	// Create a ChanSink without setting input channel
+	cs := Chan[string]()
+
+	// Call Open without setting input - should return ErrInputChannelUndefined
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	sinkErrCh := cs.Open(ctx)
+
+	select {
+	case err := <-sinkErrCh:
+		if err == nil {
+			t.Fatal("Expected error when input channel is not set, but got nil")
+		}
+		if err != api.ErrInputChannelUndefined {
+			t.Fatalf("Expected ErrInputChannelUndefined, but got: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Context timed out waiting for error")
 	}
 }

--- a/sinks/chansink_test.go
+++ b/sinks/chansink_test.go
@@ -1,0 +1,142 @@
+package sinks
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestChanSink_Open(t *testing.T) {
+	outputChan := make(chan string)
+	cs := Chan[string](outputChan)
+
+	inputChan := make(chan interface{})
+	go func() {
+		inputChan <- "A"
+		inputChan <- "B"
+		inputChan <- "C"
+		close(inputChan)
+	}()
+	cs.SetInput(inputChan)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	sinkErr := cs.Open(ctx)
+
+	var receivedData []string
+	doneReceiving := make(chan struct{})
+
+	go func() {
+		defer close(doneReceiving)
+		for data := range cs.Get() {
+			receivedData = append(receivedData, data)
+		}
+	}()
+
+	select {
+	case err := <-sinkErr:
+		if err != nil {
+			t.Fatalf("ChanSink.Open() returned an error: %v", err)
+		}
+	case <-ctx.Done():
+		// This case should ideally not be hit if the sink closes properly.
+		// If it is, it might indicate the sink didn't close when the input channel closed.
+		t.Log("Context timed out, checking received data.")
+	}
+
+	// Wait for the receiving goroutine to finish.
+	// This is important to ensure all data is collected before assertions.
+	<-doneReceiving
+
+	expectedData := []string{"A", "B", "C"}
+	if !reflect.DeepEqual(expectedData, receivedData) {
+		t.Errorf("Received data did not match expected data. Got %v, expected %v", receivedData, expectedData)
+	}
+
+	// Check if the sink's output channel was closed by the sink (indirectly via the receiving goroutine)
+	// This is a bit tricky to test directly for a send-only channel from the sink's perspective.
+	// However, if the receiving goroutine exited, it implies the channel was closed.
+	// A more direct test might involve trying to send to cs.Get() after it's supposed to be closed,
+	// but that's not how this sink is designed to be used.
+}
+
+func TestChanSink_Open_ContextCancel(t *testing.T) {
+	outputChan := make(chan int)
+	cs := Chan[int](outputChan)
+	inputChan := make(chan interface{})
+
+	cs.SetInput(inputChan)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sinkErrCh := cs.Open(ctx)
+
+	// Cancel the context after a short delay
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	// Consume from the output channel to prevent blockage
+	go func() {
+		for range cs.Get() {
+			// Discard data
+		}
+	}()
+
+	select {
+	case err := <-sinkErrCh:
+		if err != nil {
+			t.Fatalf("ChanSink.Open() returned an unexpected error: %v", err)
+		}
+		// If err is nil, it means the sink closed gracefully, which is expected after context cancellation.
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("ChanSink did not close after context cancellation")
+	}
+}
+
+func TestChanSink_Open_WrongDataType(t *testing.T) {
+	outputChan := make(chan string)
+	cs := Chan[string](outputChan) // Expecting string
+	inputChan := make(chan interface{})
+
+	go func() {
+		inputChan <- "CorrectType"
+		inputChan <- 123 // Incorrect type
+		inputChan <- "AnotherCorrectType"
+		close(inputChan)
+	}()
+	cs.SetInput(inputChan)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	sinkErr := cs.Open(ctx)
+
+	var receivedData []string
+	doneReceiving := make(chan struct{})
+	go func() {
+		defer close(doneReceiving)
+		for data := range cs.Get() {
+			receivedData = append(receivedData, data)
+		}
+	}()
+
+	select {
+	case err := <-sinkErr:
+		if err != nil {
+			t.Fatalf("ChanSink.Open() returned an error: %v", err)
+		}
+	case <-ctx.Done():
+		t.Log("Context timed out, checking received data.")
+	}
+
+	<-doneReceiving
+
+	expectedData := []string{"CorrectType", "AnotherCorrectType"}
+	if !reflect.DeepEqual(expectedData, receivedData) {
+		t.Errorf("Received data did not match expected data. Got %v, expected %v", receivedData, expectedData)
+	}
+}

--- a/sinks/slice.go
+++ b/sinks/slice.go
@@ -39,8 +39,8 @@ func (s *SliceSink[IN, SLICE]) SetLogFunc(f api.StreamLogFunc) {
 	s.logf = f
 }
 
-// Open starts the collector and returns and waits on the returned
-// channel for the collector to be done or an error to be received.
+// Open opens the sink to start collecting items. It returns a channel
+// that will receive an error if the sink encounters an error during setup operation.
 func (s *SliceSink[IN, SLICE]) Open(ctx context.Context) <-chan error {
 	result := make(chan error)
 

--- a/stream/stream_sink_test.go
+++ b/stream/stream_sink_test.go
@@ -136,3 +136,46 @@ func TestStreamToSlice(t *testing.T) {
 		t.Fatal("Took too long")
 	}
 }
+
+func TestStreamToChan(t *testing.T) {
+	src := sources.Slice([][]string{
+		{"request", "/i/a", "00:11:51:AA", "accepted"},
+		{"response", "/i/a/", "00:11:51:AA", "served"},
+		{"request", "/i/b", "00:11:22:33", "accepted"},
+		{"response", "/i/b", "00:11:22:33", "served"},
+		{"request", "/i/c", "00:11:51:AA", "accepted"},
+		{"request", "/i/a", "00:11:51:AA", "accepted"},
+		{"response", "/i/a/", "00:11:51:AA", "served"},
+		{"request", "/i/b", "00:11:22:33", "accepted"},
+		{"response", "/i/b", "00:11:22:33", "served"},
+		{"request", "/i/c", "00:11:51:AA", "accepted"},
+	})
+
+	snk := sinks.Chan[[]string]()
+	strm := From(src)
+	strm.WithLogSink(sinks.Func(testutil.LogSinkFunc(t)))
+	strm.Into(snk)
+
+	var receivedData [][]string
+	doneReceiving := make(chan struct{})
+
+	go func() {
+		defer close(doneReceiving)
+		for data := range snk.Get() {
+			receivedData = append(receivedData, data)
+		}
+	}()
+
+	select {
+	case err := <-strm.Open(context.Background()):
+		if err != nil {
+			t.Fatal(err)
+		}
+		<-doneReceiving
+		if len(receivedData) != 10 {
+			t.Errorf("unexpected sink data: want 10, got %d", len(receivedData))
+		}
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("Took too long")
+	}
+}


### PR DESCRIPTION
The `ChanSink` allows streaming data from an Automi pipeline to be collected into a channel. Items in the channel can be accessed as shown below:

```go
src := sources.Slice([][]string{ ... }
snk := sinks.Chan[[]string]()
strm := From(src)
strm.WithLogSink(sinks.Func(testutil.LogSinkFunc(t)))
strm.Into(snk)

...
var receivedData [][]string
for data := range snk.Get() {
    receivedData = append(receivedData, data)
}
```

See documentation for detail.

Fixes #42 